### PR TITLE
Test tidyups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ blackdoor
 [![JavaDocs](https://img.shields.io/maven-central/v/black.door/blackdoor-lib.svg?label=javadocs)](https://www.javadoc.io/doc/black.door/blackdoor-lib)  
 [![Maven Central](https://img.shields.io/maven-central/v/black.door/blackdoor-lib.svg)]()
 
-A library of various classes that may be usefull including misclanious utilites, simplified crypto and some data structures.
+A library of various classes that may be usefull including miscellaneous utilites, simplified crypto and some data structures.
 The latest stable release will be in blackdoor.jar in the master branch. 
 Newest developement releases will be in the dev branch and old stable releases will be in the version numbered branches (VersonxxRevisionxxStepxx).

--- a/src/test/java/black/door/json/DeruloTest.java
+++ b/src/test/java/black/door/json/DeruloTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by nfischer on 5/23/15.
@@ -55,7 +55,7 @@ public class DeruloTest {
     @Test
     public void fromJson(){
         String m2 = Derulo.toJSON(map);
-        assertTrue(map.equals(Derulo.fromJSON(m2)));
+        assertEquals(map, Derulo.fromJSON(m2));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class DeruloTest {
         String m2 = Derulo.toJSON(simpleMap);
         Map parsed = new JsonObject(m2);
         //System.out.println(Derulo.toJSON(2, parsed));
-        assertTrue(simpleMap.equals(parsed));
+        assertEquals(simpleMap, parsed);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class DeruloTest {
         String arr = Derulo.toJSON(simpleList);
         List parsed = new JsonArray(arr);
         //System.out.println(Derulo.toJSON(4, parsed));
-        assertTrue(simpleList.equals(parsed));
+        assertEquals(simpleList, parsed);
     }
 
     @Test

--- a/src/test/java/black/door/json/JsonHasherTest.java
+++ b/src/test/java/black/door/json/JsonHasherTest.java
@@ -53,7 +53,7 @@ public class JsonHasherTest {
 
 		List<String> mapKeyset = new ArrayList<>(map.keySet());
 		Collections.sort(mapKeyset);
-		assertTrue(new ArrayList<>(json.keySet()).equals(mapKeyset));
+		assertEquals(new ArrayList<>(json.keySet()), mapKeyset);
 
 		System.out.println(cannon);
 		System.out.println(Derulo.toJSON(2,Derulo.fromJSON(cannon)));
@@ -88,6 +88,6 @@ public class JsonHasherTest {
 		copy.remove("null");
 
 		assertArrayEquals(JsonHasher.hash(copy), hasher.hash());
-		assertTrue(original.equals(simpleMap));
+		assertEquals(original, simpleMap);
 	}
 }

--- a/src/test/java/black/door/net/SocketIOWrapperTest.java
+++ b/src/test/java/black/door/net/SocketIOWrapperTest.java
@@ -8,6 +8,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SocketIOWrapperTest {
@@ -43,7 +44,7 @@ public class SocketIOWrapperTest {
 				String inString;
 				try {
 					inString = io1.read();
-					assertTrue(inString.equals(testString));
+					assertEquals(inString, testString);
 					io1.write(inString);
 				} catch (IOException e) {
 					// TODO Auto-generated catch block
@@ -54,7 +55,7 @@ public class SocketIOWrapperTest {
 		
 		io2.write(testString);
 		String inString = io2.read();
-		assertTrue(inString.equals(testString));
+		assertEquals(inString, testString);
 	}
 
 	public void tearDown() throws IOException {

--- a/src/test/java/black/door/net/http/tools/HttpTest.java
+++ b/src/test/java/black/door/net/http/tools/HttpTest.java
@@ -16,6 +16,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -109,7 +110,7 @@ public class HttpTest {
                 "Accept: */*\n\n";
 
         HttpRequest simpleRequest = HttpRequest.parse(simple.getBytes(StandardCharsets.US_ASCII));
-        assertTrue(simpleRequest.getVerb().equals(HttpVerb.POST));
+        assertEquals(simpleRequest.getVerb(), HttpVerb.POST);
         System.out.println(simpleRequest);
         
 		//POST

--- a/src/test/java/black/door/net/http/tools/HttpTest.java
+++ b/src/test/java/black/door/net/http/tools/HttpTest.java
@@ -1,7 +1,5 @@
 package black.door.net.http.tools;
 
-import static black.door.util.DBP.printdebugln;
-import static black.door.util.DBP.println;
 import static org.junit.Assert.assertEquals;
 
 import black.door.util.DBP;

--- a/src/test/java/black/door/net/http/tools/ParseToolsTest.java
+++ b/src/test/java/black/door/net/http/tools/ParseToolsTest.java
@@ -6,7 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Created by nfischer on 7/19/2015.
@@ -16,7 +17,7 @@ public class ParseToolsTest {
 	@Test
 	public void testNextLine() throws Exception {
 		InputStream is = new ByteArrayInputStream("Hello world\n".getBytes());
-		assertTrue(ParseTools.nextLine(is).equals("Hello world"));
+		assertEquals(ParseTools.nextLine(is), "Hello world");
 		try {
 			ParseTools.nextLine(is);
 			fail();

--- a/src/test/java/black/door/net/http/tools/URLToolsTest.java
+++ b/src/test/java/black/door/net/http/tools/URLToolsTest.java
@@ -28,10 +28,10 @@ public class URLToolsTest {
 	public void testParseQueries() throws Exception {
 		Map queries = URLTools.parseQueries(googleSearch);
 		System.out.println(queries);
-		assertTrue(queries.get("sourceid").equals("chrome-instant"));
-		assertTrue(queries.get("ion").equals("1"));
-		assertTrue(queries.get("espv").equals("2"));
-		assertTrue(queries.get("ie").equals("UTF-8"));
+		assertEquals(queries.get("sourceid"), "chrome-instant");
+		assertEquals(queries.get("ion"), "1");
+		assertEquals(queries.get("espv"), "2");
+		assertEquals(queries.get("ie"), "UTF-8");
 
 		try {
 			assertTrue(URLTools.parseQueries(jsSite).isEmpty());
@@ -45,9 +45,9 @@ public class URLToolsTest {
 	public void testParseRef(){
 		Map refs = URLTools.parseRef(googleSearch);
 		System.out.println(refs);
-		assertTrue(refs.get("q").equals("sample%20url"));
+		assertEquals(refs.get("q"), "sample%20url");
 
 		Map anchor = URLTools.parseRef(jsSite);
-		assertTrue(anchor.get("id").equals("people"));
+		assertEquals(anchor.get("id"), "people");
 	}
 }


### PR DESCRIPTION
Some minor cleanups to tests. & a typo fix to `README.md`

`assertTrue(x.equals(y))` is more clearly done as `assertEquals(x, y)`

Remove some unused imports